### PR TITLE
Fix release workflow permissions for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT for protected branch access, fallback to GITHUB_TOKEN
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
       
       - name: Configure Git
         run: |
@@ -54,7 +55,8 @@ jobs:
       - name: Push version bump
         run: |
           # Push the commit that cargo-release created
-          git push
+          # Explicitly push to main branch
+          git push origin HEAD:main
       
       - name: Generate Release Notes
         id: notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Release
@@ -17,8 +20,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Use PAT for protected branch access, fallback to GITHUB_TOKEN
-          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Configure Git
         run: |


### PR DESCRIPTION
## Summary
Adds explicit write permissions to the release workflow to fix the 403 error when pushing version bumps.

## Problem
The release workflow failed with:
```
remote: Permission to clafollett/maos.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/clafollett/maos/': The requested URL returned error: 403
```

## Solution
Added explicit `contents: write` permission to the workflow. This grants the GITHUB_TOKEN permission to:
- Push commits to the repository
- Create tags
- Create releases

According to GitHub docs, workflows need explicit permissions when the repository has restricted default permissions.

## Test plan
- [ ] Verify workflow can push commits with the write permission
- [ ] Confirm cargo-release version bumps are pushed successfully
- [ ] Check that GitHub Release creation still works

🤖 Generated with [Claude Code](https://claude.ai/code)