### PR TITLE
feat: add Release Drafter for automated release notes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,8 +19,7 @@
   "env": {
     "BASH_DEFAULT_TIMEOUT_MS": "1200000",
     "BASH_MAX_TIMEOUT_MS": "1200000",
-    "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "1",
-    "MAOS_PROJECT_ROOT_DIR": "~/Repositories/maos"
+    "CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR": "1"
   },
   "hooks": {
     "PreToolUse": [

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,14 +9,21 @@
 <!-- Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change. -->
 
 ## Type of Change
-- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-- [ ] ✨ New feature (non-breaking change which adds functionality)
-- [ ] 🛠️ Refactoring (code improvement without changing functionality)
-- [ ] 📚 Documentation update
-- [ ] 🎨 Style/UI update
-- [ ] ⚡ Performance improvement
-- [ ] 🧪 Tests (adding missing tests or correcting existing tests)
-- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
+
+Please select the primary type and add the corresponding label to this PR:
+
+- [ ] 🐛 Bug fix (non-breaking change which fixes an issue) → **Label: `bug`**
+- [ ] ✨ New feature (non-breaking change which adds functionality) → **Label: `feature`**
+- [ ] 🛠️ Refactoring (code improvement without changing functionality) → **Label: `refactor`**
+- [ ] 📚 Documentation update → **Label: `documentation`**
+- [ ] 🎨 Style/UI update → **Label: `style`**
+- [ ] ⚡ Performance improvement → **Label: `performance`**
+- [ ] 🧪 Tests (adding missing tests or correcting existing tests) → **Label: `tests`**
+- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change) → **Label: `breaking`**
+- [ ] 🔒 Security fix → **Label: `security`**
+- [ ] 🏗️ Infrastructure/Build/CI → **Label: `infrastructure`**
+
+**Important**: Please add the appropriate label(s) to your PR for automatic release notes categorization!
 
 ## Visuals
 <!-- Screenshots or demo links if applicable -->

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,107 @@
+# Release Drafter Configuration
+# This file configures how release notes are automatically generated
+
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+# Categories for grouping changes
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '⚡ Performance'
+    labels:
+      - 'performance'
+      - 'perf'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🔒 Security'
+    labels:
+      - 'security'
+  - title: '🛠️ Refactoring'
+    labels:
+      - 'refactor'
+      - 'refactoring'
+  - title: '📚 Documentation'
+    labels:
+      - 'documentation'
+      - 'docs'
+  - title: '🧪 Tests'
+    labels:
+      - 'tests'
+      - 'test'
+  - title: '🏗️ Infrastructure'
+    labels:
+      - 'infrastructure'
+      - 'ci'
+      - 'build'
+  - title: '💥 Breaking Changes'
+    labels:
+      - 'breaking'
+      - 'breaking-change'
+
+# Exclude labels from release notes
+exclude-labels:
+  - 'skip-release'
+  - 'skip-changelog'
+  - 'no-release'
+
+# Version resolver (for pre-1.0, we'll mostly use patch bumps)
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'feature'  # New features bump minor version
+  patch:
+    labels:
+      - 'patch'
+      - 'bug'
+      - 'bugfix'
+      - 'fix'
+      - 'performance'
+      - 'documentation'
+      - 'refactor'
+      - 'tests'
+      - 'infrastructure'
+  default: patch
+
+# Template for each change line
+change-template: '- $TITLE by @$AUTHOR in #$NUMBER'
+
+# Template for when there's no changes
+no-changes-template: '- No changes in this release'
+
+# Main release template
+template: |
+  ## What's Changed
+  
+  $CHANGES
+  
+  ## New Contributors
+  $CONTRIBUTORS
+  
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+  
+  ---
+  
+  **Note**: This is a pre-1.0 release. Breaking changes may occur without notice.
+  
+  ## Installation
+  
+  ```bash
+  cargo install maos
+  ```
+  
+  Or clone and build:
+  ```bash
+  git clone https://github.com/clafollett/maos.git
+  cd maos
+  cargo build --release
+  ```

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -87,7 +87,7 @@ template: |
   ## New Contributors
   $CONTRIBUTORS
   
-  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+  **Full Changelog**: https://github.com/clafollett/maos/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
   
   ---
   

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  # Also run when PRs are merged
-  pull_request:
-    types: [opened, reopened, synchronize]
   # Allow manual trigger to update draft
   workflow_dispatch:
 
@@ -20,8 +17,8 @@ jobs:
     steps:
       - name: Update Release Draft
         uses: release-drafter/release-drafter@v5
-        # Only run on main branch pushes (not PRs)
-        if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch')
+        # Only run on main branch pushes or manual triggers
+        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,28 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  # Also run when PRs are merged
+  pull_request:
+    types: [opened, reopened, synchronize]
+  # Allow manual trigger to update draft
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Release Draft
+        uses: release-drafter/release-drafter@v5
+        # Only run on main branch pushes (not PRs)
+        if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch')
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,17 +5,27 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump type'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && !contains(github.event.head_commit.message, 'chore(release)')
+    # Remove the if condition since it's now manual-only
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,61 +42,50 @@ jobs:
       - name: Install cargo-release
         run: cargo install cargo-release --version '^0.25'
       
-      - name: Determine version bump
+      - name: Set version bump
         id: version
         run: |
-          # For pre-1.0, we only do patch bumps unless explicitly marked as milestone
-          # Look for [milestone] tag to trigger minor version bump
-          if git log -1 --pretty=%B | grep -q "\[milestone\]"; then
-            echo "bump=minor" >> $GITHUB_OUTPUT
-            echo "Pre-1.0 milestone release detected"
-          else
-            echo "bump=patch" >> $GITHUB_OUTPUT
-            echo "Standard patch release for pre-1.0 development"
-          fi
+          echo "bump=${{ github.event.inputs.version_bump }}" >> $GITHUB_OUTPUT
+          echo "Manual release triggered with ${{ github.event.inputs.version_bump }} version bump"
       
       - name: Bump version
+        id: bump
         run: |
           # cargo-release will bump version AND commit with message from Cargo.toml config
           cargo release ${{ steps.version.outputs.bump }} --no-confirm --execute
           
-          # Get the new version
+          # Get the new version and output it
           NEW_VERSION=$(grep "^version" Cargo.toml | head -1 | cut -d '"' -f2)
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
       
       - name: Push version bump
         run: |
           # Push the commit that cargo-release created
-          # Explicitly push to main branch
-          git push origin HEAD:main
+          # Push to current branch, then create/push tag
+          git push origin HEAD:${{ github.ref_name }}
+          git tag v${{ steps.bump.outputs.version }}
+          git push origin v${{ steps.bump.outputs.version }}
       
-      - name: Generate Release Notes
-        id: notes
+      - name: Publish Draft Release
         run: |
-          # Extract commit messages since last tag
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -z "$LAST_TAG" ]; then
-            COMMITS=$(git log --pretty=format:"- %s" --no-merges)
-          else
-            COMMITS=$(git log ${LAST_TAG}..HEAD --pretty=format:"- %s" --no-merges)
-          fi
+          # Find and publish the draft release
+          DRAFT_RELEASE=$(gh release list --draft --limit 1 --json tagName -q '.[0].tagName')
           
-          # Create release notes
-          echo "RELEASE_NOTES<<EOF" >> $GITHUB_OUTPUT
-          echo "## What's Changed" >> $GITHUB_OUTPUT
-          echo "" >> $GITHUB_OUTPUT
-          echo "$COMMITS" >> $GITHUB_OUTPUT
-          echo "" >> $GITHUB_OUTPUT
-          echo "**Note**: This is a pre-1.0 release. Breaking changes may occur without notice." >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-      
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: v${{ env.NEW_VERSION }}
-          name: Release v${{ env.NEW_VERSION }}
-          body: ${{ steps.notes.outputs.RELEASE_NOTES }}
-          draft: false
-          prerelease: true  # All pre-1.0 releases are prereleases
+          if [ -n "$DRAFT_RELEASE" ]; then
+            echo "Publishing draft release: $DRAFT_RELEASE"
+            # Update the tag to match our version
+            gh release edit $DRAFT_RELEASE \
+              --tag v${{ steps.bump.outputs.version }} \
+              --draft=false \
+              --prerelease
+          else
+            echo "No draft release found. Creating a new release..."
+            # Fallback: create a new release if no draft exists
+            gh release create v${{ steps.bump.outputs.version }} \
+              --title "Release v${{ steps.bump.outputs.version }}" \
+              --generate-notes \
+              --prerelease
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    # Remove the if condition since it's now manual-only
+    # Removed automatic trigger condition since workflow is now manual-only
     steps:
       - uses: actions/checkout@v4
         with:
@@ -70,7 +70,7 @@ jobs:
       - name: Publish Draft Release
         run: |
           # Find and publish the draft release
-          DRAFT_RELEASE=$(gh release list --draft --limit 1 --json tagName -q '.[0].tagName')
+          DRAFT_RELEASE=$(gh release list --draft --limit 1 --json tagName -q 'if length > 0 then .[0].tagName else empty end')
           
           if [ -n "$DRAFT_RELEASE" ]; then
             echo "Publishing draft release: $DRAFT_RELEASE"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,15 +62,15 @@ jobs:
       - name: Push version bump
         run: |
           # Push the commit that cargo-release created
-          # Push to current branch, then create/push tag
-          git push origin HEAD:${{ github.ref_name }}
+          # Push to current branch (get actual branch name, not github.ref_name)
+          git push origin HEAD:$(git rev-parse --abbrev-ref HEAD)
           git tag v${{ steps.bump.outputs.version }}
           git push origin v${{ steps.bump.outputs.version }}
       
       - name: Publish Draft Release
         run: |
           # Find and publish the draft release
-          DRAFT_RELEASE=$(gh release list --draft --limit 1 --json tagName -q 'if length > 0 then .[0].tagName else empty end')
+          DRAFT_RELEASE=$(gh release list --draft --limit 1 --json tagName -q '.[0].tagName // empty')
           
           if [ -n "$DRAFT_RELEASE" ]; then
             echo "Publishing draft release: $DRAFT_RELEASE"


### PR DESCRIPTION
## Summary
- Set up Release Drafter workflow to maintain draft releases that accumulate PR changes
- Configure PR categorization with 12 labels for organized release notes
- Convert release workflow to manual-only with `workflow_dispatch`

## Why This Change?
Previously, each PR would trigger an automatic release. Now we can:
1. Bundle multiple PRs into single releases
2. Generate categorized release notes automatically
3. Control when releases happen (manual trigger)
4. Maintain draft releases that accumulate changes over time

## What's Included
- **Release Drafter workflow** (`.github/workflows/release-drafter.yml`): Maintains draft releases on main branch pushes
- **Release Drafter config** (`.github/release-drafter.yml`): Defines categories and formatting
- **Updated PR template**: Instructions for adding proper labels
- **Modified release workflow**: Now manual-only with `workflow_dispatch` trigger

## Test Plan
- [x] Pre-commit hooks pass
- [ ] Merge to main and verify Release Drafter creates a draft
- [ ] Verify "Run workflow" button appears on Actions tab after merge
- [ ] Test manual release with accumulated changes

## Important Note
The "Run workflow" button will only appear after these changes are merged to main, as GitHub only shows `workflow_dispatch` workflows that exist on the default branch.

🤖 Generated with [Claude Code](https://claude.ai/code)